### PR TITLE
Added jTDAL

### DIFF
--- a/gen/template-engines.yaml
+++ b/gen/template-engines.yaml
@@ -171,6 +171,9 @@ template_engines:
     - name: Hogan.js
       description: A compiler for the Mustache templating language with separate scanning, parsing and code generation phases
       url: https://github.com/twitter/hogan.js
+    - name: jTDAL
+      description: Small template engine based on Zope TAL, using data attributes
+      url: https://github.com/StefanoBalocco/jTDAL
     - name: Lodash
       description: A utility library for working with arrays, numbers, objects, strings, and creating composite functions
       url: https://github.com/lodash/lodash


### PR DESCRIPTION
I've added a small javascript template engine that I'm developing since 2019.
Is based on Zope TAL but using data-* attributes.